### PR TITLE
clarify that the range of rdf:predicate is rdfs:Resource

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -728,7 +728,7 @@ href="https://www.w3.org/TR/2004/REC-rdf-primer-20040210/#reification">RDF2004 p
         statement is the statement made by a token of an RDF triple. The
         subject of an RDF statement is the instance of <code><a href="#ch_resource">rdfs:Resource</a></code>
         identified by the subject of the triple. The predicate of an RDF
-        statement is the instance of <code><a href="#ch_property">rdf:Property</a></code>
+        statement is the instance of <code><a href="#ch_resource">rdf:Resource</a></code>
         identified by the predicate of the triple. The object of an RDF
         statement is the instance of <code><a href="#ch_resource">rdfs:Resource</a></code>
         identified by the object of the triple.
@@ -740,6 +740,15 @@ href="https://www.w3.org/TR/2004/REC-rdf-primer-20040210/#reification">RDF2004 p
         <code><a href="#ch_subject">rdf:subject</a></code>
         and <code><a href="#ch_object">rdf:object</a></code> properties.
       </p>
+
+      <p>
+	RDF statements are not triples in an RDF graph so their values
+	for <code><a href="#ch_predicate">rdf:predicate</a></code> do not need to be instances of
+	<code><a href="#ch_property">rdf:Property</a></code> in that graph,
+	although in most cases they will be.
+      </p>
+
+
     </section>
 
     <section id="ch_subject">
@@ -770,7 +779,7 @@ href="https://www.w3.org/TR/2004/REC-rdf-primer-20040210/#reification">RDF2004 p
       </blockquote>
       <p>states that S is an instance of <code><a href="#ch_statement">rdf:Statement</a></code>,
         that P is an instance of
-        <code><a href="#ch_property">rdf:Property</a></code> and that the
+        <code><a href="#ch_resource">rdfs:Resource</a></code> and that the
         predicate
         of S is P.</p>
       <p>The <a href="#ch_domain"><code>rdfs:domain</code></a> of


### PR DESCRIPTION
Fix for https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_31 as per https://lists.w3.org/Archives/Public/public-rdf-comments/2021Dec/0002.html

Should fix the last part of #2 

Marked as enhancement, but could also be considered to be just editorial.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/pull/15.html" title="Last updated on Apr 13, 2023, 5:32 PM UTC (eea05f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/15/ec41c71...eea05f5.html" title="Last updated on Apr 13, 2023, 5:32 PM UTC (eea05f5)">Diff</a>