### PR TITLE
Update prevRecShortname to rdf11-schema

### DIFF
--- a/spec/common/fixup.js
+++ b/spec/common/fixup.js
@@ -46,7 +46,7 @@ function unComment(utils, content) {
 // If content is a self-citation, replace it with the document name
 function noSelfCite(utils, content) {
   if (content.toUpperCase() === `[[[${respecConfig.shortName}]]]`.toUpperCase()) {
-    return respecConfig.title + '(this document)';
+    return respecConfig.title + ' (this document)';
   } else {
     return content;
   }

--- a/spec/common/local-biblio.js
+++ b/spec/common/local-biblio.js
@@ -1,14 +1,4 @@
 var localBibliography = {
-  CBD: {
-    "title": "CBD - Concise Bounded Description",
-    "href": "https://www.w3.org/Submission/CBD/",
-    "authors": [
-      "Patrick Stickler, Nokia"
-    ],
-    "rawDate": "2005-06-03",
-    "publisher": "W3C",
-    "status": "W3C Member Submission"
-  },
   ISO24707: {
     id: "ISO24707",
     title: "Information technology — Common Logic (CL) — A framework for a family of logic-based languages",

--- a/spec/common/rdf-related.html
+++ b/spec/common/rdf-related.html
@@ -1,7 +1,9 @@
 <h4>Set of Documents</h4>
-<p>This document is one of ten RDF 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of ten RDF 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
-<p>RDF 1.2 Recommendations:</p>
+<p>RDF 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>
@@ -14,3 +16,4 @@
   <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
+</details>

--- a/spec/common/related.html
+++ b/spec/common/related.html
@@ -1,7 +1,9 @@
 <h4>Set of Documents</h4>
-<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
-<p>RDF 1.2 Recommendations:</p>
+<p>RDF 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>
@@ -15,7 +17,7 @@
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
 
-<p>SPARQL 1.2 Recommendations:</p>
+<p>SPARQL 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>
@@ -30,3 +32,4 @@
   <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
 </ol>
+</details>

--- a/spec/common/sparql-related.html
+++ b/spec/common/sparql-related.html
@@ -1,7 +1,9 @@
 <h4>Set of Documents</h4>
-<p>This document is one of twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
-<p>SPARQL 1.2 Recommendations:</p>
+<p>SPARQL 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>
@@ -16,3 +18,4 @@
   <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
 </ol>
+</details>

--- a/spec/index.html
+++ b/spec/index.html
@@ -16,8 +16,8 @@
 
       previousPublishDate:  "2014-02-25",
       previousMaturity:     "REC",
-      prevRecShortname:     "rdf-schema",
-      prevRecURI:           "https://www.w3.org/TR/2014/REC-rdf-schema-20140225/",
+      prevRecShortname:     "rdf11-schema",
+      prevRecURI:           "https://www.w3.org/TR/rdf11-schema/",
       
       // editors, add as many as you like
       // only "name" is required


### PR DESCRIPTION
and make similar modification to prevRecURI.

Fixes #23.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/pull/24.html" title="Last updated on Jun 15, 2023, 8:44 PM UTC (c277fdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/24/6bd987b...c277fdd.html" title="Last updated on Jun 15, 2023, 8:44 PM UTC (c277fdd)">Diff</a>