### PR TITLE
added rdf:JSON datatype

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -285,15 +285,11 @@ model
 
   <section id="ch_json" class="informative">
     <h3>rdf:JSON</h3>
-    <!--p>The class <code>rdf:JSON</code> is the class of
+    <p>The class <code>rdf:JSON</code> is the class of
       <a data-cite="RDF12-CONCEPTS#section-JSON">JSON literal values</a>.
       <code>rdf:JSON</code> is an instance of
       <code>rdfs:Datatype</code> and a <a href="#def-subclass">subclass</a>
-      of <a href="#ch_literal"><code>rdfs:Literal</code></a>.</p-->
-    <p class="issue" data-number="7">
-      The `rdf:JSON` datatype is originally defined in
-      <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section 10.2 The `rdf:JSON` Datatype</a>
-      in [[?JSON-LD11]].
+      of <a href="#ch_literal"><code>rdfs:Literal</code></a>.</p>
     </p>
   </section>
 
@@ -931,10 +927,10 @@ href="https://www.w3.org/TR/2004/REC-rdf-primer-20040210/#reification">RDF2004 p
           <td><a href="#ch_xmlliteral">rdf:XMLLiteral</a></td>
           <td>The class of XML literal values.</td>
         </tr>
-        <!--tr>
+        <tr>
           <td><a href="#ch_json">rdf:JSON</a></td>
           <td>The class of JSON literal values.</td>
-        </tr-->
+        </tr>
         <tr>
           <td><a href="#ch_class">rdfs:Class</a></td>
           <td>The class of classes.</td>
@@ -1210,7 +1206,7 @@ href="https://www.w3.org/TR/2004/REC-rdf-primer-20040210/#reification">RDF2004 p
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
-    
+    <li>Added the datatype <code>rdf:JSON</code>.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -286,7 +286,7 @@ model
   <section id="ch_json" class="informative">
     <h3>rdf:JSON</h3>
     <p>The class <code>rdf:JSON</code> is the class of
-      <a data-cite="RDF12-CONCEPTS#section-JSON">JSON literal values</a>.
+      <a data-cite="RDF12-CONCEPTS#section-json">JSON literal values</a>.
       <code>rdf:JSON</code> is an instance of
       <code>rdfs:Datatype</code> and a <a href="#def-subclass">subclass</a>
       of <a href="#ch_literal"><code>rdfs:Literal</code></a>.</p>


### PR DESCRIPTION
- added `rdf:JSON` in Classes section
- added `rdf:JSON` in RDF Schema summary section
- added information about `rdf:JSON` in Changes between RDF 1.1 and RDF 1.2 appendix

Depends on https://github.com/w3c/rdf-concepts/pull/62


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/pull/27.html" title="Last updated on Sep 16, 2023, 9:18 AM UTC (23b66bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/27/f706e62...23b66bb.html" title="Last updated on Sep 16, 2023, 9:18 AM UTC (23b66bb)">Diff</a>