### PR TITLE
Move reference versions of the RDF and RDFS vocabulary to this repo

### DIFF
--- a/.github/workflows/generate-versions.yml
+++ b/.github/workflows/generate-versions.yml
@@ -34,13 +34,3 @@ jobs:
             /home/runner/bin/riot --syntax=turtle --output=jsonld ns/${base}.ttl > ns/${base}.jsonld
           done
 
-      # Commit and push any changes (RDF/XML, JSON-LD files)
-      - name: Commit generated files
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          if [[ `git status --porcelain` ]]; then
-            git add ns/*.rdf ns/*.jsonld
-            git commit -m "Generate RDF/XML and JSON-LD for updated vocabularies"
-            git push
-

--- a/.github/workflows/generate-versions.yml
+++ b/.github/workflows/generate-versions.yml
@@ -1,0 +1,46 @@
+name: Generate RDF Serializations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ns/*.ttl'
+
+jobs:
+  generate-versions:
+    name: Generate RDF Versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install Apache Jena tools (including riot)
+      - name: Install Jena
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y apache2-utils openjdk-11-jre-headless
+          curl -L https://dlcdn.apache.org/jena/binaries/apache-jena-4.8.0.tar.gz \
+            | tar xz --strip-components=1 -C /home/runner
+          echo 'export PATH="/home/runner/bin:$PATH"' >> $GITHUB_ENV
+
+      # Convert all .ttl files to RDF/XML and JSON-LD using riot
+      - name: Convert RDF to multiple formats
+        run: |
+          for file in ns/*.ttl; do
+            base=$(basename "$file" .ttl)
+            # Convert Turtle -> RDF/XML
+            /home/runner/bin/riot --syntax=turtle --output=rdfxml ns/${base}.ttl > ns/${base}.rdf
+            # Convert Turtle -> JSON-LD
+            /home/runner/bin/riot --syntax=turtle --output=jsonld ns/${base}.ttl > ns/${base}.jsonld
+          done
+
+      # Commit and push any changes (RDF/XML, JSON-LD files)
+      - name: Commit generated files
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          if [[ `git status --porcelain` ]]; then
+            git add ns/*.rdf ns/*.jsonld
+            git commit -m "Generate RDF/XML and JSON-LD for updated vocabularies"
+            git push
+

--- a/ns/rdf.ttl
+++ b/ns/rdf.ttl
@@ -1,0 +1,154 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+<http://www.w3.org/1999/02/22-rdf-syntax-ns#> a owl:Ontology ;
+	dc:title "The RDF Concepts Vocabulary (RDF)" ;
+	dc:date "2019-12-16" ;
+	dc:description "This is the RDF Schema for the RDF vocabulary terms in the RDF Namespace, defined in RDF 1.1 Concepts." .
+
+rdf:HTML a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Literal ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:seeAlso <http://www.w3.org/TR/rdf11-concepts/#section-html> ;
+	rdfs:label "HTML" ;
+	rdfs:comment "The datatype of RDF literals storing fragments of HTML content" .
+
+rdf:langString a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Literal ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:seeAlso <http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal> ;
+	rdfs:label "langString" ;
+	rdfs:comment "The datatype of language-tagged string values" .
+
+rdf:PlainLiteral a rdfs:Datatype ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:subClassOf rdfs:Literal ;
+	rdfs:seeAlso <http://www.w3.org/TR/rdf-plain-literal/> ;
+	rdfs:label "PlainLiteral" ;
+	rdfs:comment "The class of plain (i.e. untyped) literal values, as used in RIF and OWL 2" .
+
+rdf:type a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "type" ;
+	rdfs:comment "The subject is an instance of a class." ;
+	rdfs:range rdfs:Class ;
+	rdfs:domain rdfs:Resource .
+
+rdf:Property a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "Property" ;
+	rdfs:comment "The class of RDF properties." ;
+	rdfs:subClassOf rdfs:Resource .
+
+rdf:Statement a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "Statement" ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:comment "The class of RDF statements." .
+
+rdf:subject a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "subject" ;
+	rdfs:comment "The subject of the subject RDF statement." ;
+	rdfs:domain rdf:Statement ;
+	rdfs:range rdfs:Resource .
+
+rdf:predicate a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "predicate" ;
+	rdfs:comment "The predicate of the subject RDF statement." ;
+	rdfs:domain rdf:Statement ;
+	rdfs:range rdfs:Resource .
+
+rdf:object a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "object" ;
+	rdfs:comment "The object of the subject RDF statement." ;
+	rdfs:domain rdf:Statement ;
+	rdfs:range rdfs:Resource .
+
+rdf:Bag a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "Bag" ;
+	rdfs:comment "The class of unordered containers." ;
+	rdfs:subClassOf rdfs:Container .
+
+rdf:Seq a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "Seq" ;
+	rdfs:comment "The class of ordered containers." ;
+	rdfs:subClassOf rdfs:Container .
+
+rdf:Alt a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "Alt" ;
+	rdfs:comment "The class of containers of alternatives." ;
+	rdfs:subClassOf rdfs:Container .
+
+rdf:value a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "value" ;
+	rdfs:comment "Idiomatic property used for structured values." ;
+	rdfs:domain rdfs:Resource ;
+	rdfs:range rdfs:Resource .
+
+rdf:List a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "List" ;
+	rdfs:comment "The class of RDF Lists." ;
+	rdfs:subClassOf rdfs:Resource .
+
+rdf:nil a rdf:List ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "nil" ;
+	rdfs:comment "The empty list, with no items in it. If the rest of a list is nil then the list has no more items in it." .
+
+rdf:first a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "first" ;
+	rdfs:comment "The first item in the subject RDF list." ;
+	rdfs:domain rdf:List ;
+	rdfs:range rdfs:Resource .
+
+rdf:rest a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "rest" ;
+	rdfs:comment "The rest of the subject RDF list after the first item." ;
+	rdfs:domain rdf:List ;
+	rdfs:range rdf:List .
+
+rdf:XMLLiteral a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Literal ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "XMLLiteral" ;
+	rdfs:comment "The datatype of XML literal values." .
+
+rdf:JSON a rdfs:Datatype ;
+	rdfs:label "JSON" ;
+	rdfs:comment "The datatype of RDF literals storing JSON content." ;
+	rdfs:subClassOf rdfs:Literal ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#the-rdf-json-datatype> .
+
+rdf:CompoundLiteral a rdfs:Class ;
+	rdfs:label "CompoundLiteral" ;
+	rdfs:comment "A class representing a compound literal." ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#the-rdf-compoundliteral-class-and-the-rdf-language-and-rdf-direction-properties> .
+
+rdf:language a rdf:Property ;
+	rdfs:label "language" ;
+	rdfs:comment "The language component of a CompoundLiteral." ;
+	rdfs:domain rdf:CompoundLiteral ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#the-rdf-compoundliteral-class-and-the-rdf-language-and-rdf-direction-properties> .
+
+rdf:direction a rdf:Property ;
+	rdfs:label "direction" ;
+	rdfs:comment "The base direction component of a CompoundLiteral." ;
+	rdfs:domain rdf:CompoundLiteral ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#the-rdf-compoundliteral-class-and-the-rdf-language-and-rdf-direction-properties> .

--- a/ns/rdf.ttl
+++ b/ns/rdf.ttl
@@ -130,7 +130,7 @@ rdf:JSON a rdfs:Datatype ;
 	rdfs:comment "The datatype of RDF literals storing JSON content." ;
 	rdfs:subClassOf rdfs:Literal ;
 	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
-	rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#the-rdf-json-datatype> .
+        rdfs:seeAlso <https://www.w3.org/TR/rdf-concepts/#section-json> .
 
 rdf:CompoundLiteral a rdfs:Class ;
 	rdfs:label "CompoundLiteral" ;

--- a/ns/rdfs.ttl
+++ b/ns/rdfs.ttl
@@ -1,0 +1,108 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+<http://www.w3.org/2000/01/rdf-schema#> a owl:Ontology ;
+	dc:title "The RDF Schema vocabulary (RDFS)" .
+
+rdfs:Resource a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Resource" ;
+	rdfs:comment "The class resource, everything." .
+
+rdfs:Class a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Class" ;
+	rdfs:comment "The class of classes." ;
+	rdfs:subClassOf rdfs:Resource .
+
+rdfs:subClassOf a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "subClassOf" ;
+	rdfs:comment "The subject is a subclass of a class." ;
+	rdfs:range rdfs:Class ;
+	rdfs:domain rdfs:Class .
+
+rdfs:subPropertyOf a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "subPropertyOf" ;
+	rdfs:comment "The subject is a subproperty of a property." ;
+	rdfs:range rdf:Property ;
+	rdfs:domain rdf:Property .
+
+rdfs:comment a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "comment" ;
+	rdfs:comment "A description of the subject resource." ;
+	rdfs:domain rdfs:Resource ;
+	rdfs:range rdfs:Literal .
+
+rdfs:label a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "label" ;
+	rdfs:comment "A human-readable name for the subject." ;
+	rdfs:domain rdfs:Resource ;
+	rdfs:range rdfs:Literal .
+
+rdfs:domain a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "domain" ;
+	rdfs:comment "A domain of the subject property." ;
+	rdfs:range rdfs:Class ;
+	rdfs:domain rdf:Property .
+
+rdfs:range a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "range" ;
+	rdfs:comment "A range of the subject property." ;
+	rdfs:range rdfs:Class ;
+	rdfs:domain rdf:Property .
+
+rdfs:seeAlso a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "seeAlso" ;
+	rdfs:comment "Further information about the subject resource." ;
+	rdfs:range rdfs:Resource ;
+	rdfs:domain rdfs:Resource .
+
+rdfs:isDefinedBy a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:subPropertyOf rdfs:seeAlso ;
+	rdfs:label "isDefinedBy" ;
+	rdfs:comment "The definition of the subject resource." ;
+	rdfs:range rdfs:Resource ;
+	rdfs:domain rdfs:Resource .
+
+rdfs:Literal a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Literal" ;
+	rdfs:comment "The class of literal values, eg. textual strings and integers." ;
+	rdfs:subClassOf rdfs:Resource .
+
+rdfs:Container a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Container" ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:comment "The class of RDF containers." .
+
+rdfs:ContainerMembershipProperty a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "ContainerMembershipProperty" ;
+	rdfs:comment """The class of container membership properties, rdf:_1, rdf:_2, ..., all of which are sub-properties of 'member'.""" ;
+	rdfs:subClassOf rdf:Property .
+
+rdfs:member a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "member" ;
+	rdfs:comment "A member of the subject resource." ;
+	rdfs:domain rdfs:Resource ;
+	rdfs:range rdfs:Resource .
+
+rdfs:Datatype a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Datatype" ;
+	rdfs:comment "The class of RDF datatypes." ;
+	rdfs:subClassOf rdfs:Class .
+
+<http://www.w3.org/2000/01/rdf-schema#> rdfs:seeAlso <http://www.w3.org/2000/01/rdf-schema-more> .

--- a/ns/rdfs.ttl
+++ b/ns/rdfs.ttl
@@ -104,5 +104,3 @@ rdfs:Datatype a rdfs:Class ;
 	rdfs:label "Datatype" ;
 	rdfs:comment "The class of RDF datatypes." ;
 	rdfs:subClassOf rdfs:Class .
-
-<http://www.w3.org/2000/01/rdf-schema#> rdfs:seeAlso <http://www.w3.org/2000/01/rdf-schema-more> .


### PR DESCRIPTION
The goal of this PR is to have a reference version of the RDF and RDFS vocabularies in this repository,
where future changes will be tracked,
and to reflect the final version on https://www.w3.org/ when we publish the recommendation.

As a start, this PR introduces
* `ns/rdf.ttl`: retrieved from https://www.w3.org/1999/02/22-rdf-syntax-ns (accept:text/turtle)
* `ns/rdfs.ttl`: retrieved from https://www.w3.org/2000/01/rdf-schema (accept:text/turtle)

Plan for this PR:

* [x] import vocabularies from w3.org/
* [ ] setup github actions to generate other versions (RDF/XML, JSON-LD, others?)

Plan for later
* setup a way to redirect clients requesting HTML to the relevant section of the specifiction