### PR TITLE
dirLangString to spec and to ns

### DIFF
--- a/ns/rdf.ttl
+++ b/ns/rdf.ttl
@@ -22,6 +22,12 @@ rdf:langString a rdfs:Datatype ;
 	rdfs:label "langString" ;
 	rdfs:comment "The datatype of language-tagged string values" .
 
+rdf:dirLangString a rdfs:Datatype ;
+	rdfs:subClassOf rdfs:Literal ;
+	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;
+	rdfs:label "dirLangString" ;
+	rdfs:comment "The datatype of directional language-tagged string values, which includes a language tag and a base direction (either 'ltr' or 'rtl')" .
+
 rdf:PlainLiteral a rdfs:Datatype ;
 	owl:deprecated true ;
 	rdfs:isDefinedBy <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ;

--- a/spec/index.html
+++ b/spec/index.html
@@ -265,6 +265,14 @@ model
       of <a href="#ch_literal"><code>rdfs:Literal</code></a>.</p>
   </section>
 
+  <section id="ch_dirlangstring">
+    <h3>rdf:dirLangString</h3>
+    <p>The class <code>rdf:dirLangString</code> is the class of
+      <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged string values</a>. <code>rdf:dirLangString</code> is an instance of
+      <code>rdfs:Datatype</code> and a <a href="#def-subclass">subclass</a>
+      of <a href="#ch_literal"><code>rdfs:Literal</code></a>.</p>
+  </section>
+
   <section id="ch_html" class="informative">
     <h3>rdf:HTML</h3>
     <p>The class <code>rdf:HTML</code> is the class of
@@ -944,6 +952,10 @@ href="https://www.w3.org/TR/2004/REC-rdf-primer-20040210/#reification">RDF2004 p
           <td>The class of language-tagged string literal values.</td>
         </tr>
         <tr>
+          <td><a href="#ch_dirlangstring">rdf:dirLangString</a></td>
+          <td>The class of directional language-tagged string literal values.</td>
+        </tr>
+        <tr>
           <td><a href="#ch_html">rdf:HTML</a></td>
           <td>The class of HTML literal values.</td>
         </tr>
@@ -1241,6 +1253,7 @@ href="https://www.w3.org/TR/2004/REC-rdf-primer-20040210/#reification">RDF2004 p
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
+    <li>Added the datatype <code>rdf:dirLangString</code>.
     <li>Added the datatype <code>rdf:JSON</code>.</li>
     <li>Added the class <code>rdf:Proposition</code> and the property <code>rdf:reifies</code>.</li>
   </ul>


### PR DESCRIPTION
- `rdf:dirLangString` added to the spec.
- `rdf:dirLangString` added to `rdf.ttl`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/pull/44.html" title="Last updated on Mar 13, 2025, 9:49 PM UTC (bcfe4d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-schema/44/ce8fc8e...bcfe4d4.html" title="Last updated on Mar 13, 2025, 9:49 PM UTC (bcfe4d4)">Diff</a>