### PR TITLE
Declare XSD 1.1 facets as rdf:Property and annotate them

### DIFF
--- a/ns/rdf-xsd.ttl
+++ b/ns/rdf-xsd.ttl
@@ -226,3 +226,74 @@ xsd:NCName a rdfs:Datatype ;
   rdfs:label "NCName" ;
   rdfs:comment "XML 'non-colonized' names matching the NCName production (i.e., Name without the colon). Derived from xsd:Name. Lexical form: XML NCName (same as Name but disallowing ':')." .
 
+# Facets
+xsd:length a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-length> ;
+    rdfs:label "length" ;
+    rdfs:comment "Exact length of the value; units depend on the base type (characters for string/anyURI, octets for binary, items for list types)." .
+
+xsd:minLength a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-minLength> ;
+    rdfs:label "min length" ;
+    rdfs:comment "Minimum length of the value; measured in characters (string/anyURI), octets (binary), or list items for list types." .
+
+xsd:maxLength a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-maxLength> ;
+    rdfs:label "max length" ;
+    rdfs:comment "Maximum length of the value; measured in characters (string/anyURI), octets (binary), or list items for list types." .
+
+xsd:pattern a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-pattern> ;
+    rdfs:label "pattern" ;
+    rdfs:comment "Constrains the lexical space by requiring each literal to match the supplied regular expression(s)." .
+
+xsd:enumeration a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-enumeration> ;
+    rdfs:label "enumeration" ;
+    rdfs:comment "Restricts the value space to a specified set of values (no ordering implied by the facet itself)." .
+
+xsd:whiteSpace a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-whiteSpace> ;
+    rdfs:label "white space" ;
+    rdfs:comment "Controls whitespace normalization during validation (preserve, replace, collapse), which can indirectly affect lexical forms." .
+
+xsd:maxInclusive a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-maxInclusive> ;
+    rdfs:label "max inclusive" ;
+    rdfs:comment "Inclusive upper bound of the value space for ordered datatypes." .
+
+xsd:maxExclusive a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-maxExclusive> ;
+    rdfs:label "max exclusive" ;
+    rdfs:comment "Exclusive upper bound of the value space for ordered datatypes." .
+
+xsd:minExclusive a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-minExclusive> ;
+    rdfs:label "min exclusive" ;
+    rdfs:comment "Exclusive lower bound of the value space for ordered datatypes." .
+
+xsd:minInclusive a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-minInclusive> ;
+    rdfs:label "min inclusive" ;
+    rdfs:comment "Inclusive lower bound of the value space for ordered datatypes." .
+
+xsd:totalDigits a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-totalDigits> ;
+    rdfs:label "total digits" ;
+    rdfs:comment "Upper bound on the total number of decimal digits in a value (both before and after the decimal point)." .
+
+xsd:fractionDigits a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-fractionDigits> ;
+    rdfs:label "fraction digits" ;
+    rdfs:comment "Upper bound on the number of digits allowed in the fractional part of a decimal value; must not exceed totalDigits." .
+
+xsd:assertions a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-assertions> ;
+    rdfs:label "assertions" ;
+    rdfs:comment "Requires values to satisfy given XPath expressions; the facet value is a sequence of assertion components." .
+
+xsd:explicitTimezone a rdf:Property ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema11-2/#rf-explicitTimezone> ;
+    rdfs:label "explicit timezone" ;
+    rdfs:comment "Three-valued facet (required | prohibited | optional) controlling the presence of a time-zone offset for date/time datatypes." .
+


### PR DESCRIPTION
### Summary

This pull request adds explicit declarations for the XML Schema 1.1 facets (e.g., `xsd:minInclusive`, `xsd:maxInclusive`, `xsd:pattern`, etc.) as `rdf:Property` in the RDF/XSD ontology file. Each facet IRI is annotated with `rdfs:label`, `rdfs:comment`, and `rdfs:isDefinedBy` pointing to the corresponding section of the XML Schema Part 2 specification.

No existing IRIs are modified and no domains/ranges are introduced, so there is no behavior change for consumers; this simply documents how these facet IRIs are actually used in RDF encodings of datatype restrictions.

---

### Motivation

The current file enumerates XSD datatypes commonly used in RDF. OWL 2’s RDF mapping expresses datatype restrictions via `owl:withRestrictions` as lists of blank nodes whose predicates are facet IRIs. In practice, these facet IRIs occur in the predicate position of RDF triples and function as properties. Making this explicit:
- improves readability and discoverability for users and tooling,
- provides stable labels and comments,
- and anchors each facet to its normative XSD 1.1 definition.

---

### Proposed Changes

Add facet declarations as `rdf:Property` with metadata:
   - xsd:length, xsd:minLength, xsd:maxLength
   - xsd:pattern, xsd:enumeration, xsd:whiteSpace
   - xsd:maxInclusive, xsd:maxExclusive, xsd:minExclusive, xsd:minInclusive
   - xsd:totalDigits, xsd:fractionDigits
   - xsd:assertions, xsd:explicitTimezone

---

### Rationale (single, precise argument)

In OWL 2’s, each restriction on a datatype is encoded as RDF triples where the facet IRI appears as the predicate of a triple attached to a blank node in the `owl:withRestrictions` list. For example:
```
  _:r  xsd:minInclusive  "1"^^xsd:integer .
  _:r  xsd:maxInclusive  "2"^^xsd:integer .
  :x a rdfs:Datatype ;
     owl:onDatatype :y ;
     owl:withRestrictions ( _:r ) .
```

Because these facet IRIs are used in predicate position in RDF, declaring them as `rdf:Property` accurately reflects their operational role in the graph and enables attaching standard metadata (`rdfs:label`, `rdfs:isDefinedBy`, `rdfs:comment`) without introducing stronger semantics than intended.

---

### Example (end-to-end)
```
  :x a rdfs:Datatype ;
     owl:onDatatype :y ;
     owl:withRestrictions (
         [ xsd:maxInclusive 2 ]
         [ xsd:minInclusive 1 ]
     ) .
```
This corresponds to triples where `xsd:maxInclusive` and `xsd:minInclusive` are predicates, hence properties.

---

### Backwards Compatibility

- Safe change. These are lightweight declarations and annotations; they do not change the meaning of existing data.
- No stronger semantics are added (e.g., we deliberately avoid `rdfs:domain`/`rdfs:range` or declaring these as `owl:DatatypeProperty`).

---

### Implementation Notes

- All `rdfs:isDefinedBy` IRIs point to the normative XSD 1.1 Part 2 facet sections.
- Labels and comments paraphrase the spec in concise, practitioner-friendly language.

---

### References

- XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes, W3C Recommendation.
- OWL 2 Web Ontology Language: Mapping to RDF Graphs, W3C Recommendation (datatype restrictions via `owl:withRestrictions`).

---

### Checklist

- [x] Adds facet IRIs as `rdf:Property`
- [x] Adds labels/comments/isDefinedBy
- [x] No domains/ranges introduced
- [x] No breaking changes
